### PR TITLE
update jaeger config to support agent

### DIFF
--- a/exporter/jaeger/jaeger.go
+++ b/exporter/jaeger/jaeger.go
@@ -19,7 +19,8 @@ func Exporter(ctx context.Context, cfg opencensus.Config) (*jaeger.Exporter, err
 		return nil, errDisabled
 	}
 	e, err := jaeger.NewExporter(jaeger.Options{
-		CollectorEndpoint: cfg.Exporters.Jaeger.Endpoint,
+		AgentEndpoint:     cfg.Exporters.Jaeger.AgentEndpoint,
+		CollectorEndpoint: cfg.Exporters.Jaeger.CollectorEndpoint,
 		BufferMaxCount:    cfg.Exporters.Jaeger.BufferMaxCount,
 		Process: jaeger.Process{
 			ServiceName: cfg.Exporters.Jaeger.ServiceName,

--- a/exporter/jaeger/jaeger.go
+++ b/exporter/jaeger/jaeger.go
@@ -20,7 +20,7 @@ func Exporter(ctx context.Context, cfg opencensus.Config) (*jaeger.Exporter, err
 	}
 	e, err := jaeger.NewExporter(jaeger.Options{
 		AgentEndpoint:     cfg.Exporters.Jaeger.AgentEndpoint,
-		CollectorEndpoint: cfg.Exporters.Jaeger.CollectorEndpoint,
+		CollectorEndpoint: cfg.Exporters.Jaeger.Endpoint,
 		BufferMaxCount:    cfg.Exporters.Jaeger.BufferMaxCount,
 		Process: jaeger.Process{
 			ServiceName: cfg.Exporters.Jaeger.ServiceName,

--- a/go.mod
+++ b/go.mod
@@ -67,5 +67,3 @@ require (
 	gopkg.in/ini.v1 v1.51.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/krakendio/krakend-opencensus/v2 v2.0.1 => github.com/CodyManshack-SAP/krakend-opencensus/v2 v2.0.2

--- a/go.mod
+++ b/go.mod
@@ -67,3 +67,5 @@ require (
 	gopkg.in/ini.v1 v1.51.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/krakendio/krakend-opencensus/v2 v2.0.1 => github.com/CodyManshack-SAP/krakend-opencensus/v2 v2.0.2

--- a/opencensus.go
+++ b/opencensus.go
@@ -187,7 +187,7 @@ type ZipkinConfig struct {
 
 type JaegerConfig struct {
 	AgentEndpoint     string `json:"agent_endpoint"`
-	CollectorEndpoint string `json:"collector_endpoint"`
+	Endpoint          string `json:"endpoint"`
 	ServiceName       string `json:"service_name"`
 	BufferMaxCount    int    `json:"buffer_max_count"`
 }

--- a/opencensus.go
+++ b/opencensus.go
@@ -186,9 +186,10 @@ type ZipkinConfig struct {
 }
 
 type JaegerConfig struct {
-	Endpoint       string `json:"endpoint"`
-	ServiceName    string `json:"service_name"`
-	BufferMaxCount int    `json:"buffer_max_count"`
+	AgentEndpoint     string `json:"agent_endpoint"`
+	CollectorEndpoint string `json:"collector_endpoint"`
+	ServiceName       string `json:"service_name"`
+	BufferMaxCount    int    `json:"buffer_max_count"`
 }
 
 type PrometheusConfig struct {


### PR DESCRIPTION
This PR addresses issue #71 raised a few days ago.

## Testing this PR with docker
### Prepare KrakenD
1. in your local **krakend-ce** directory, place the following line at the end of the `go.mod` file: `replace github.com/krakendio/krakend-opencensus/v2 v2.0.1 => github.com/CodyManshack-SAP/krakend-opencensus/v2 v2.0.2`
2. run `make docker` to build the krakend executable inside the docker image
3. update the `telemetry/opencensus/exporters/jaeger` **ExtraConfig{}** object in the KrakenD config (`/krakend.json`) with either; `jaeger:6831` for the jaeger agent (UDP) or `http://localhost:14268` for the jaeger collector (HTTP) 

### Prepare Docker
4. create a docker network `docker network create jaeger-tracing`

### Run Containers
5. run **jaeger all-in-one** official docker image with ports bound `docker run -d --name jaeger -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 -p 5775:5775/udp -p 6831:6831/udp -p 6832:6832/udp -p 5778:5778 -p 16686:16686 -p 14268:14268 -p 9411:9411 --network="jaeger-exporter" jaegertracing/all-in-one:latest`
6. run the built **krakend** docker image with ports bound `docker run -d -p 8080:8080 --mount type=bind,source="$(pwd)"/krakend.json,target=/etc/krakend/krakend.json --network="jaeger-exporter" devopsfaith/krakend:2.1.1`

### View Reported Traces
7. Open `http://localhost:16686/search` in your browser to view the Jaeger UI where the traces are reported